### PR TITLE
Revert "gui: only support tertiary display if QTI_BSP is defined"

### DIFF
--- a/include/gui/ISurfaceComposer.h
+++ b/include/gui/ISurfaceComposer.h
@@ -58,11 +58,9 @@ public:
     };
 
     enum {
-        eDisplayIdMain = 0,
-        eDisplayIdHdmi = 1,
-#ifdef QTI_BSP
+        eDisplayIdMain     = 0,
+        eDisplayIdHdmi     = 1,
         eDisplayIdTertiary = 2
-#endif
     };
 
     enum Rotation {


### PR DESCRIPTION
This reverts commit cbd3e07921a7e7525d88c7606b1b8aeb32441804.

Change-Id: I2a0f130dc64a9ebcbcaef36cfe973c759824cf8b