### PR TITLE
Revert "Revert "gui: only support tertiary display if QTI_BSP is defi…

### DIFF
--- a/include/gui/ISurfaceComposer.h
+++ b/include/gui/ISurfaceComposer.h
@@ -58,9 +58,11 @@ public:
     };
 
     enum {
-        eDisplayIdMain     = 0,
-        eDisplayIdHdmi     = 1,
+        eDisplayIdMain = 0,
+        eDisplayIdHdmi = 1,
+#ifdef QTI_BSP
         eDisplayIdTertiary = 2
+#endif
     };
 
     enum Rotation {


### PR DESCRIPTION
…ned""

This reverts commit fd95bb1c240eea33b0c491b1b569091d4f3d7525.

Change-Id: I0acbd3a8ba91f33e1ad60b14093101811683e04f